### PR TITLE
@craigspaeth Accounts for italics with bold, also cleans out style completely

### DIFF
--- a/index.js
+++ b/index.js
@@ -50,10 +50,15 @@
         traverse(el);
         if(el.nodeName == 'SPAN') {
           if (el.style.fontWeight == 'bold') {
-            el.style.removeProperty('font');
+            if(el.style.fontStyle == 'italic'){
+              el.removeAttribute('style');
+              el.style.fontStyle = 'italic';
+            }else{
+              el.removeAttribute('style');
+            }
             replaceNode(el, 'B');
           } else if (el.style.fontStyle == 'italic') {
-            el.style.removeProperty('font');
+            el.removeAttribute('style');
             replaceNode(el, 'I');
           }
         }


### PR DESCRIPTION
Closes https://github.com/artsy/positron/issues/379

This would just clear style completely and add `font-style: italics` to the bold element if they are used together. Does it seem a bit hack-y to you? Happy to change anything around - this fixes the issue mentioned but maybe there is a cleaner way. 

![scribe](https://cloud.githubusercontent.com/assets/2236794/8169861/57be0638-137a-11e5-8feb-e38cbfe4ce4e.gif)
