### PR TITLE
@craigspaeth Checks numerical font-weight

### DIFF
--- a/index.js
+++ b/index.js
@@ -49,15 +49,15 @@
         nextSibling = el.nextElementSibling;
         traverse(el);
         if(el.nodeName == 'SPAN') {
-          if (el.style.fontWeight == 'bold') {
-            if(el.style.fontStyle == 'italic'){
+          if (el.style.fontWeight === 'bold' || el.style.fontWeight === '700') {
+            if(el.style.fontStyle === 'italic'){
               el.removeAttribute('style');
               el.style.fontStyle = 'italic';
             }else{
               el.removeAttribute('style');
             }
             replaceNode(el, 'B');
-          } else if (el.style.fontStyle == 'italic') {
+          } else if (el.style.fontStyle === 'italic') {
             el.removeAttribute('style');
             replaceNode(el, 'I');
           }


### PR DESCRIPTION
Looks like Google Docs changed over to using numerical font-weight instead of `bold`
![screen shot 2015-09-09 at 6 03 25 pm](https://cloud.githubusercontent.com/assets/2236794/9775578/64db64ea-571e-11e5-9d5a-4e8e37c31f7c.png)
before and after:
![2015-09-09_1813](https://cloud.githubusercontent.com/assets/2236794/9775605/95a83a30-571e-11e5-8df1-972278fbc076.png)
