### PR TITLE
@craigspaeth Creates new italic node instead of adding to styling properties

### DIFF
--- a/index.js
+++ b/index.js
@@ -52,11 +52,15 @@
           if (el.style.fontWeight === 'bold' || el.style.fontWeight === '700') {
             if(el.style.fontStyle === 'italic'){
               el.removeAttribute('style');
-              el.style.fontStyle = 'italic';
+              var newNode = document.createElement('B');
+              var copy = el.cloneNode(true);
+              newNode.appendChild(copy);
+              replaceNode(copy, 'I');
+              el.parentNode.replaceChild(newNode, el);
             }else{
               el.removeAttribute('style');
+              replaceNode(el, 'B');
             }
-            replaceNode(el, 'B');
           } else if (el.style.fontStyle === 'italic') {
             el.removeAttribute('style');
             replaceNode(el, 'I');

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "scribe-plugin-sanitize-google-doc",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "A Scribe plugin for sanitizing html pasted from Google Docs",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Closes https://github.com/artsy/positron/issues/559, https://github.com/artsy/positron/issues/504
The issue was we were saving the italic styling in the font-style of a `<b>` tag. Not sure why I was doing that in the first place. This cleans it up and just adds an `<i>` child node in the `<b>` tag. 
Until next time...
